### PR TITLE
Refine hero banner and fix image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,6 +568,19 @@
         </div>
     </section>
 
+    <section class="py-16 bg-white">
+        <div class="container mx-auto px-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
+                <div>
+                    <p class="text-lg">Dr. YD Sookoo, a passionate and forward-thinking general practitioner, proudly works alongside her father, Dr. D Sookoo, in their family medical practice — a unique collaboration that bridges generations of medical expertise. This partnership blends Dr. D Sookoo’s decades of trusted experience with Dr. YD Sookoo’s fresh, evidence-based approach to modern healthcare. Together, they offer patients a holistic and well-rounded standard of care, deeply rooted in compassion, continuity, and family values. Their dynamic reflects a powerful legacy in motion — where tradition meets innovation, and the shared mission of healing spans across generations.</p>
+                </div>
+                <div class="flex justify-center md:justify-end">
+                    <img src="assets/images/d_sookoo.jpg" alt="Dr. D Sookoo" class="max-w-xs rounded-lg shadow-lg">
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Footer -->
     <footer class="bg-highlight text-white py-12">
         <div class="container mx-auto px-4">

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ h1, h2, h3, h4, h5, h6 {
     font-family: 'Montserrat', sans-serif;
 }
 .hero-bg {
-    background-image: linear-gradient(rgba(45, 49, 66, 0.7), rgba(45, 49, 66, 0.7)), url('https://images.unsplash.com/photo-1519494026892-80bbd2d6fd0d?ixlib=rb-4.0.3&auto=format&fit=crop&w=1953&q=80');
+    background-image: linear-gradient(rgba(45, 49, 66, 0.7), rgba(45, 49, 66, 0.7)), url('https://images.unsplash.com/photo-EKPk2Z9G6CU?auto=format&fit=crop&w=1953&q=80&blur=5');
     background-size: cover;
     background-position: center;
 }


### PR DESCRIPTION
## Summary
- replace hero banner with stable Unsplash link
- add family legacy section above footer
- reference existing `d_sookoo.jpg` image
- remove unused PNG

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868f3a333c08333bb5f55ae8e355c1c